### PR TITLE
Stack korora patch 1

### DIFF
--- a/Template SSL check LLD-4.2.xml
+++ b/Template SSL check LLD-4.2.xml
@@ -398,7 +398,7 @@ return JSON.stringify(dnames);</params>
                             <history>10d</history>
                             <trends>0</trends>
                             <status>0</status>
-                            <value_type>3</value_type>
+                            <value_type>1</value_type>
                             <allowed_hosts/>
                             <units/>
                             <snmpv3_contextname/>

--- a/Template SSL check LLD.xml
+++ b/Template SSL check LLD.xml
@@ -196,7 +196,7 @@ SSL certificate on {#URL}:{#PORT} expires in less than 3 week</description>
                             <delay>1h</delay>
                             <history>10d</history>
                             <trends>0</trends>
-                            <value_type>1</value_type>
+                            <value_type>CHAR</value_type>
                             <applications>
                                 <application>
                                     <name>SSL Checks</name>

--- a/Template SSL check LLD.xml
+++ b/Template SSL check LLD.xml
@@ -196,7 +196,7 @@ SSL certificate on {#URL}:{#PORT} expires in less than 3 week</description>
                             <delay>1h</delay>
                             <history>10d</history>
                             <trends>0</trends>
-                            <value_type>CHAR</value_type>
+                            <value_type>1</value_type>
                             <applications>
                                 <application>
                                     <name>SSL Checks</name>


### PR DESCRIPTION
I am using the 4.2 template on 5.0.3. It was defaulting to "numeric (unsigned)"  for the certificate issuer when it should be character. 
When set to "numeric (unsigned)" the template has an error as the issuer is a string.
Using the numerical identifier for character string (eg: 1) as per the documentation.
https://www.zabbix.com/documentation/current/manual/api/reference/item/object

Thanks for your work on this template! It's very useful.